### PR TITLE
Drawing Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ isometricView.add(new Path(new Point[]{
 # Include in your project
 ## Using JCenter
 ```groovy
-compile 'io.fabianterhorst:Isometric:0.0.6.5'
+compile 'io.fabianterhorst:Isometric:0.0.7'
 ```
 
 ### Available Shapes

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,8 +14,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        versionCode 6
-        versionName "0.0.6"
+        versionCode 7
+        versionName "0.0.7"
         testInstrumentationRunner 'io.fabianterhorst.isometric.screenshot.IsometricTestRunner'
     }
     buildTypes {
@@ -37,7 +37,7 @@ android {
 def siteUrl = 'https://github.com/FabianTerhorst/Isometric'
 def gitUrl = 'https://github.com/FabianTerhorst/Isometric.git'
 
-version = "0.0.6.5"
+version = "0.0.7"
 group = "io.fabianterhorst"
 
 install {

--- a/lib/src/main/java/io/fabianterhorst/isometric/Isometric.java
+++ b/lib/src/main/java/io/fabianterhorst/isometric/Isometric.java
@@ -129,8 +129,8 @@ public class Isometric {
         this.originX = width / 2;
         this.originY = height * 0.9;
 
-        int itemIndex = 0;
-        while (itemIndex < items.size()) {
+        int itemIndex = 0, itemSize = items.size();
+        while (itemIndex < itemSize) {
             Item item = items.get(itemIndex);
 
             item.transformedPoints = new Point[item.path.points.length];
@@ -145,11 +145,14 @@ public class Isometric {
                 item.transformedPoints[i] = translatePoint(point);
             }
 
-            //remove item if not in view
-            //the if conditions here are ordered carefully to save computation, fail fast approach
+            /**
+             * This greatly improves drawing speed
+             * Paths must be defined in a counter-clockwise rotation order
+             */
             if ((cull && cullPath(item)) || !this.itemInDrawingBounds(item)) {
                 //the path is invisible. It does not need to be considered any more
                 this.items.remove(itemIndex);
+                itemSize--;
                 continue;
             }
             else
@@ -185,7 +188,7 @@ public class Isometric {
     }
 
     private boolean itemInDrawingBounds(Item item) {
-        for (int i = 0; i< item.transformedPoints.length; i++)
+        for (int i = 0, len = item.transformedPoints.length; i< len; i++)
         {
             //if any point is in bounds, the item is worth drawing
             if (item.transformedPoints[i].getX() >= 0 &&

--- a/lib/src/main/java/io/fabianterhorst/isometric/Isometric.java
+++ b/lib/src/main/java/io/fabianterhorst/isometric/Isometric.java
@@ -114,7 +114,7 @@ public class Isometric {
         return color.lighten(brightness * this.colorDifference, this.lightColor);
     }
 
-    public void measure(int width, int height, boolean sort, boolean cull) {
+    public void measure(int width, int height, boolean sort, boolean cull, boolean boundsCheck) {
 
         //only perform measure operation:
         //if the bounds have changed
@@ -145,11 +145,9 @@ public class Isometric {
                 item.transformedPoints[i] = translatePoint(point);
             }
 
-            /**
-             * This greatly improves drawing speed
-             * Paths must be defined in a counter-clockwise rotation order
-             */
-            if ((cull && cullPath(item)) || !this.itemInDrawingBounds(item)) {
+            //remove item if not in view
+            //the if conditions here are ordered carefully to save computation, fail fast approach
+            if ((cull && cullPath(item)) || (boundsCheck && !this.itemInDrawingBounds(item))) {
                 //the path is invisible. It does not need to be considered any more
                 this.items.remove(itemIndex);
                 itemSize--;

--- a/lib/src/main/java/io/fabianterhorst/isometric/IsometricView.java
+++ b/lib/src/main/java/io/fabianterhorst/isometric/IsometricView.java
@@ -22,7 +22,7 @@ public class IsometricView extends View {
 
     private OnItemClickListener listener;
 
-    private boolean sort = true, cull = false;
+    private boolean sort = true, cull = false, boundsCheck = false;
 
     public IsometricView(Context context) {
         super(context);
@@ -32,10 +32,19 @@ public class IsometricView extends View {
         this.sort = sort;
     }
 
-    //This greatly improves drawing speed
-    //Paths must be defined in a counter-clockwise rotation order
+    /**
+     * This greatly improves drawing speed
+     * Paths must be defined in a counter-clockwise rotation order
+     */
     public void setCull(boolean cull) {
         this.cull = cull;
+    }
+
+    /**
+     * This improves drawing speed by not considering items that are outside of view bounds
+     */
+    public void setBoundsCheck(boolean boundsCheck) {
+        this.boundsCheck = boundsCheck;
     }
 
     public void setClickListener(OnItemClickListener listener) {
@@ -70,7 +79,7 @@ public class IsometricView extends View {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        isometric.measure(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec), sort, cull);
+        isometric.measure(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec), sort, cull, boundsCheck);
     }
 
     @Override

--- a/lib/src/main/java/io/fabianterhorst/isometric/IsometricView.java
+++ b/lib/src/main/java/io/fabianterhorst/isometric/IsometricView.java
@@ -22,7 +22,7 @@ public class IsometricView extends View {
 
     private OnItemClickListener listener;
 
-    private boolean sort = true;
+    private boolean sort = true, cull = false;
 
     public IsometricView(Context context) {
         super(context);
@@ -30,6 +30,12 @@ public class IsometricView extends View {
 
     public void setSort(boolean sort) {
         this.sort = sort;
+    }
+
+    //This greatly improves drawing speed
+    //Paths must be defined in a counter-clockwise rotation order
+    public void setCull(boolean cull) {
+        this.cull = cull;
     }
 
     public void setClickListener(OnItemClickListener listener) {
@@ -64,7 +70,7 @@ public class IsometricView extends View {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        isometric.measure(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec), sort);
+        isometric.measure(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec), sort, cull);
     }
 
     @Override


### PR DESCRIPTION
I increased the drawing performance for my own use, I want to share so that others might be able to reap the benefits.

I made these changes because I am using Isometric to dynamically draw moving objects on screen rather than still images. My approach to increase performance was to remove unnecessary items from measuring calculations and drawing. An item is unnecessary if it is out of view of the user. 

I deemed an item out of view using 2 methods:
- [Back-Face culling](https://en.wikipedia.org/wiki/Back-face_culling) using the [Shoelace formula](https://en.wikipedia.org/wiki/Shoelace_formula)
- Standards bounds detection

A simple example of Back-Face culling can be found in drawing a cube. A cube has 6 sides, but only 3 sides are visible at any given time. Back-Face culling is the process of determining those faces that don't need to be drawn because they would be obscured from view. I implemented this with the Shoelace formula because I find this algorithm elegant, and a simple computation (fast for drawing).

I eliminated unnecessary measure calculations by tracking the current view bounds and if there were any new items to be calculated. The measure calculations will now only be performed if the bounds change, or some change has been made to the item collection being drawn.